### PR TITLE
Fix #52: End Of Prior no longer displays 'undefined' for missing fields

### DIFF
--- a/Bigfoot-Bib-Report-Initial.html
+++ b/Bigfoot-Bib-Report-Initial.html
@@ -276,7 +276,7 @@
                 const prevDOM = previousItem.dayOfMonth || 'none';
                 const prevMsgNum = previousItem.messageNumber || 'none';
                 console.log('previous Runner, Action, Time, DOM, MsgNum', prevRunner, prevAction, prevTime, prevDOM, prevMsgNum);
-                const previousRecordString = '#' + previousItem.runner + ', ' + previousItem.action + ', ' + prevTime + ', D:' + previousItem.dayOfMonth + ', M#' + previousItem.messageNumber;
+                const previousRecordString = '#' + prevRunner + ', ' + prevAction + ', ' + prevTime + ', D:' + prevDOM + ', M#' + prevMsgNum;
                 GetElementById('endOfPriorBatch').value = previousRecordString;
             }
         }

--- a/tests/issue-52-end-of-prior.md
+++ b/tests/issue-52-end-of-prior.md
@@ -1,0 +1,38 @@
+# Manual Test: Issue #52 — End Of Prior shows "undefined"
+
+The "End Of Prior" field is rendered by `copyPreviousRecordFromLsToElement()`, which
+reads the `previousRecord` object from `localStorage` and builds a display string. Missing
+properties must render as `none`, never as the literal words `undefined` or `null`.
+
+Run these checks in a browser (Firefox/Chrome) with `Bigfoot-Bib-Report-Initial.html` open.
+Use the DevTools console to seed `localStorage`, then reload the page.
+
+## 1. Valid last entry still renders correctly
+
+```js
+localStorage.setItem('previousRecord', JSON.stringify(
+  { runner: '123', action: 'IN', time: '08:30', dayOfMonth: '14', messageNumber: '5' }));
+```
+Reload. Expect End Of Prior: `#123, IN, 08:30, D:14, M#5`
+
+## 2. Missing fields render "none", not "undefined"
+
+```js
+localStorage.setItem('previousRecord', JSON.stringify({}));
+```
+Reload. Expect End Of Prior: `#none, none, none, D:none, M#none`
+FAIL if any part reads `undefined` or `null`.
+
+## 3. Partial fields (the reported failure)
+
+```js
+localStorage.setItem('previousRecord', JSON.stringify(
+  { runner: '', action: undefined, time: null, messageNumber: '5' }));
+```
+Reload. Expect End Of Prior: `#none, none, none, D:none, M#5`
+Before the fix this rendered `#, undefined, none, D:undefined, M#5`.
+
+## 4. Add / save / load unchanged
+
+- Add an IN/OUT/DROP entry and confirm End Of Prior updates to that entry.
+- Save the form (submit) and reload saved data; a valid last entry must still display correctly.


### PR DESCRIPTION
## Problem

The read-only **End Of Prior** field could display literal `undefined` values (e.g. `#, undefined, none, D:undefined, M#5`) when the stored `previousRecord` object had missing/undefined properties. Reported on Firefox 126 / Win11, present since ~v2.0.1. Fixes #52.

## Solution

`copyPreviousRecordFromLsToElement()` already computed guarded fallback variables (`prevRunner`, `prevAction`, `prevDOM`, `prevMsgNum`, each defaulting to `'none'`), but the display string was built from the raw `previousItem.*` properties — only `prevTime` used its guard. Switched the string to use the already-defined guard variables.

- One-line change; no reformatting, no renames, existing `|| 'none'` style preserved.
- No new JS syntax — safe for the older browsers this form targets.

## Result

Missing/undefined/null parts now render as `none` instead of the literal `undefined`. Valid records are unchanged (byte-for-byte).

| Scenario | Before | After |
|----------|--------|-------|
| Valid entry | `#123, IN, 08:30, D:14, M#5` | `#123, IN, 08:30, D:14, M#5` (unchanged) |
| All fields missing | `#undefined, undefined, none, D:undefined, M#undefined` | `#none, none, none, D:none, M#none` |
| Partial (reported case) | `#, undefined, none, D:undefined, M#5` | `#none, none, none, D:none, M#5` |

Added a small manual browser test note under `tests/issue-52-end-of-prior.md` (no framework introduced).

## Note / open question

Missing parts render as `none`, matching the file's existing fallback style. The issue text mentions "blank/empty" — if preferred, changing the five `|| 'none'` defaults to `|| ''` would render those parts blank instead. Happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
